### PR TITLE
Fix: Security vulnerability in pool_debug

### DIFF
--- a/src/libs/libsolv/solv/pool.c
+++ b/src/libs/libsolv/solv/pool.c
@@ -915,6 +915,7 @@ pool_debug(Pool *pool, int type, const char *format, ...)
         vprintf(format, args);
       else
         vfprintf(stderr, format, args);
+      va_end(args);
       return;
     }
   vsnprintf(buf, sizeof(buf), format, args);


### PR DESCRIPTION
This PR fixes a security vulnerability in `pool_debug()` that was cloned from openSUSE/libsolv but did not receive the security patch.

**Vulnerability Details:**
- **Affected Function**: `pool_debug()` in `src/libs/libsolv/solv/pool.c`
- **Original Fix**: https://github.com/openSUSE/libsolv/commit/8e1dba061d7962441f7e06b9a94d0ff24b158c6a

**What this PR does:**
This PR applies the same security patch that was applied to the original repository to eliminate the vulnerability in the cloned code.

**References:**
- https://github.com/openSUSE/libsolv/commit/8e1dba061d7962441f7e06b9a94d0ff24b158c6a

Please review and merge this PR to ensure your repository is protected against this vulnerability.
